### PR TITLE
fix: wire up ankiconnect_url and allow_non_localhost from config

### DIFF
--- a/anki_cli/backends/ankiconnect.py
+++ b/anki_cli/backends/ankiconnect.py
@@ -92,7 +92,11 @@ class AnkiConnectBackend(AnkiBackend):
         }
 
         try:
-            response = self._client.post(self._url, json=payload)
+            response = self._client.post(
+                self._url,
+                json=payload,
+                headers={"Connection": "close"},
+            )
             response.raise_for_status()
         except httpx.TimeoutException as exc:
             raise AnkiConnectUnavailableError(
@@ -101,6 +105,10 @@ class AnkiConnectBackend(AnkiBackend):
         except httpx.ConnectError as exc:
             raise AnkiConnectUnavailableError(
                 f"Cannot connect to AnkiConnect at {self._url}. Is Anki running with the add-on?"
+            ) from exc
+        except httpx.RemoteProtocolError as exc:
+            raise AnkiConnectUnavailableError(
+                f"AnkiConnect at {self._url} disconnected unexpectedly: {exc}"
             ) from exc
         except httpx.HTTPError as exc:
             raise AnkiConnectUnavailableError(

--- a/anki_cli/backends/detect.py
+++ b/anki_cli/backends/detect.py
@@ -40,7 +40,7 @@ def detect_backend(
     if forced == "ankiconnect":
         if not _ankiconnect_reachable(ankiconnect_url):
             raise DetectionError(
-                "AnkiConnect backend forced, but it is not reachable at localhost:8765.",
+                f"AnkiConnect backend forced, but it is not reachable at {ankiconnect_url}.",
                 exit_code=7
             )
         return DetectionResult(

--- a/anki_cli/backends/factory.py
+++ b/anki_cli/backends/factory.py
@@ -25,8 +25,10 @@ def create_backend_from_context(obj: dict[str, Any]) -> AnkiBackend:
     app_config = obj.get("app_config")
 
     ankiconnect_url = "http://localhost:8765"
+    allow_non_localhost = False
     if isinstance(app_config, AppConfig):
         ankiconnect_url = app_config.backend.ankiconnect_url
+        allow_non_localhost = app_config.backend.allow_non_localhost
 
     if backend_name == "ankiconnect":
         try:
@@ -34,6 +36,7 @@ def create_backend_from_context(obj: dict[str, Any]) -> AnkiBackend:
                 url=ankiconnect_url,
                 collection_path=collection_path,
                 verify_version=True,
+                allow_non_localhost=allow_non_localhost,
             )
         except AnkiConnectError as exc:
             raise BackendFactoryError(str(exc)) from exc

--- a/anki_cli/cli/app.py
+++ b/anki_cli/cli/app.py
@@ -133,6 +133,7 @@ def main(
         detection = detect_backend(
             forced_backend=runtime.backend,
             col_override=runtime.collection_override,
+            ankiconnect_url=runtime.app.backend.ankiconnect_url,
         )
     except DetectionError as exc:
         formatter = formatter_from_ctx(ctx)

--- a/anki_cli/models/config.py
+++ b/anki_cli/models/config.py
@@ -11,6 +11,7 @@ class CollectionConfig(BaseModel):
 class BackendConfig(BaseModel):
     prefer: str = Field(default="auto")
     ankiconnect_url: str = "http://localhost:8765"
+    allow_non_localhost: bool = False
 
 
 class DisplayConfig(BaseModel):


### PR DESCRIPTION
## Summary
- Pass `ankiconnect_url` from config to `detect_backend()` so auto-detection checks the configured URL instead of always using `localhost:8765`
- Pass `allow_non_localhost` from config to `AnkiConnectBackend` so remote connections are possible
- Add `allow_non_localhost` field to `BackendConfig` (default: `false`, no behavior change)
- Use f-string in error message to show actual URL

## Motivation
The config model already has `ankiconnect_url` but it was never passed to the detection logic, making remote AnkiConnect connections impossible. This is needed for headless setups (e.g. running anki-cli on a Raspberry Pi while Anki runs on a desktop PC via Tailscale/LAN).

## Config example
```toml
[backend]
prefer = "ankiconnect"
ankiconnect_url = "http://192.168.1.100:8765"
allow_non_localhost = true
```

## Test plan
- [x] Verified `anki notetypes` works with remote AnkiConnect via Tailscale
- [x] Verified `anki notetype:css` works with remote AnkiConnect
- [x] Verified default behavior (localhost) is unchanged when config is absent
- [x] Verified error message shows actual URL when connection fails