### PR TITLE
docs: document remote AnkiConnect configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ Backend behavior:
 - `ankiconnect`: forwards search queries to `findCards` and `findNotes`
 - `direct`: compiles queries to SQL and executes directly on the collection DB
 
+### Remote AnkiConnect
+
+To connect to AnkiConnect running on a different machine (e.g. via Tailscale or LAN):
+
+```toml
+# ~/.config/anki-cli/config.toml
+[backend]
+prefer = "ankiconnect"
+ankiconnect_url = "http://192.168.1.100:8765"
+allow_non_localhost = true
+```
+
+The remote Anki Desktop must have AnkiConnect configured to accept non-localhost connections. Set `"webBindAddress"` to a specific interface address (e.g. your Tailscale IP) or `"0.0.0.0"` for all interfaces. If binding to all interfaces, consider restricting access with firewall rules.
+
 ## Search Query Language
 
 Supported filters:

--- a/SKILL.md
+++ b/SKILL.md
@@ -245,11 +245,21 @@ Location: `~/.config/anki-cli/config.toml`
 [backend]
 prefer = "auto"
 ankiconnect_url = "http://localhost:8765"
+allow_non_localhost = false
 
 [display]
 default_output = "table"
 color = true
 day_boundary_hour = 4
+```
+
+For remote AnkiConnect (e.g. via Tailscale or LAN):
+
+```toml
+[backend]
+prefer = "ankiconnect"
+ankiconnect_url = "http://192.168.1.100:8765"
+allow_non_localhost = true
 ```
 
 ## Common Agent Workflows


### PR DESCRIPTION
## Summary
- Add "Remote AnkiConnect" section to README.md with config example and security note
- Update SKILL.md config example with `allow_non_localhost` field and remote connection example

Follows up on #9 which added remote AnkiConnect support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)